### PR TITLE
Adds option to hide skins based on quality

### DIFF
--- a/Super Duper Skin Swapper/Super Duper Skin Swapper/localizations/english.txt
+++ b/Super Duper Skin Swapper/Super Duper Skin Swapper/localizations/english.txt
@@ -25,6 +25,10 @@
 	"sdss_clean_dupes_both" : "Best normal & stat",
 	"sdss_clean_dupes_allvars" : "All variants",
 	
+	"sdss_quality_filter_title" : "Minimum wear level",
+	"sdss_quality_filter_desc" : "Hide skins below the set quality if hide duplicate skins is enabled",
+	"sdss_quality_filter_all" : "No quality filter",
+	
 	"sdss_immortal_python_title" : "Default Color to Immortal Python",
 	"sdss_immortal_python_desc" : "Use Immortal Python as default weapon color (if unlocked). Restart required.",
 	

--- a/Super Duper Skin Swapper/Super Duper Skin Swapper/lua/blackmarketmanager.lua
+++ b/Super Duper Skin Swapper/Super Duper Skin Swapper/lua/blackmarketmanager.lua
@@ -103,13 +103,18 @@ function BlackMarketManager:build_visible_cosmetics_list(tradable_list)
 			local quality_ind = get_index(quality)
 			local variant = item.bonus and "stat" or "norm"
 			local instance_id = item.instance_id
-			--If skin doesn't exist or the variant doesn't exist or the wear doesn't exist, add it
-			if not instances[entry] or not instances[entry][variant] or not instances[entry][variant][quality_ind] then
-				instances[entry] = instances[item.entry] or {}
-				instances[entry][variant] = instances[entry][variant] or {}
-				instances[entry][variant][quality_ind] = {instance_id = instance_id}
-			else
-				instances[entry][variant][quality_ind].instance_id = choose_instance(instance_id, instances[entry][variant][quality_ind].instance_id)
+			local quality_filter = SDSS:get_multi_name("sdss_quality_filter")
+			local quality_filter_index = get_index(quality_filter)
+			--If the skin is below the quality filter, ignore it
+			if quality_ind >= quality_filter_index then
+				--If skin doesn't exist or the variant doesn't exist or the wear doesn't exist, add it
+				if not instances[entry] or not instances[entry][variant] or not instances[entry][variant][quality_ind] then
+					instances[entry] = instances[item.entry] or {}
+					instances[entry][variant] = instances[entry][variant] or {}
+					instances[entry][variant][quality_ind] = {instance_id = instance_id}
+				else
+					instances[entry][variant][quality_ind].instance_id = choose_instance(instance_id, instances[entry][variant][quality_ind].instance_id)
+				end
 			end
 		end
 	end

--- a/Super Duper Skin Swapper/Super Duper Skin Swapper/lua/setup.lua
+++ b/Super Duper Skin Swapper/Super Duper Skin Swapper/lua/setup.lua
@@ -15,6 +15,7 @@ SDSS._settings = {
 	sdss_allow_variants = false,--Allow legendary attachments on akimbo/single variants
 	sdss_remove_stats = false,--Remove stats from legendary attachments
 	sdss_clean_dupes = 1,--Hide duplicates
+	ssds_quality_filter = 1,--Filter out lower quality skins
 	sdss_immortal_python = false,--Set default weapon color to Immortal Python
 	sdss_paint_scheme = 1,--Override default paint scheme of weapon colors
 	sdss_color_wear = 1,--Override default wear of weapon colors
@@ -100,6 +101,18 @@ function SDSS:get_multi_name(multi_id)
 			return "both"--Best stat and non-stat
 		elseif self._settings[multi_id] == 5 then
 			return "allvars"--Show all combinations of boost + wear
+		end
+	elseif multi_id == "sdss_quality_filter" then
+		if self._settings[multi_id] == 1 then
+			return "poor"--Battle-Worn / All
+		elseif self._settings[multi_id] == 2 then
+			return "fair"--Well-Used
+		elseif self._settings[multi_id] == 3 then
+			return "good"--Broken-In
+		elseif self._settings[multi_id] == 4 then
+			return "fine"--Lightly-Marked
+		elseif self._settings[multi_id] == 5 then
+			return "mint"--Mint-Condition
 		end
 	elseif multi_id == "sdss_color_wear" then
 		if self._settings[multi_id] == 1 then

--- a/Super Duper Skin Swapper/Super Duper Skin Swapper/menu/options.txt
+++ b/Super Duper Skin Swapper/Super Duper Skin Swapper/menu/options.txt
@@ -67,6 +67,22 @@
 			"default_value" : 1
 		},
 		{
+			"type" : "multiple_choice",
+			"id" : "sdss_quality_filter",
+			"title" : "sdss_quality_filter_title",
+			"description" : "sdss_quality_filter_desc",
+			"callback" : "sdss_callback_multi",
+			"items" : [
+				"sdss_quality_filter_all",
+				"bm_menu_quality_fair",
+				"bm_menu_quality_good",
+				"bm_menu_quality_fine",
+				"bm_menu_quality_mint"
+			],
+			"value" : "sdss_quality_filter",
+			"default_value" : 1
+		},
+		{
 			"type" : "divider",
 			"size" : 16
 		},


### PR DESCRIPTION
If duplicate skin hiding is enabled, skins with low quality / high wear can be hidden if the filter is set high enough.
Adds menu and localization to control the filter.
Optional setting, by default does nothing.

This cuts down on the number of skins potentially displayed, as daily unwanted skin drops make desired ones more difficult to find (even with duplicates hidden), assuming you aren't using worn skins. 